### PR TITLE
JokerDisplay Compatibility

### DIFF
--- a/jokers/5day.lua
+++ b/jokers/5day.lua
@@ -137,3 +137,26 @@ SMODS.Joker {
         end
     end
 }
+
+if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
+    local jd_def = JokerDisplay.Definitions
+    jd_def["j_kcva_5day"] = {
+        text = {
+            { text = localize("ph_score_cards_played") },
+            { text = " +1 ", colour = G.C.IMPORTANT },
+            { text = localize("k_rank") }
+        },
+        extra = {
+            {
+                { text = "(Excludes ", colour = G.C.JOKER_GREY, scale = 0.2 },
+                { text = localize("k_aces"), colour = G.C.IMPORTANT,  scale = 0.2 },
+                { text = ")", colour = G.C.JOKER_GREY, scale = 0.2 }
+            }
+        },
+        reminder_text = {
+            { text = "(", scale = 0.2 },
+            { text = localize("Straight", "poker_hands"), colour = G.C.IMPORTANT, scale = 0.2 },
+            { text = ")", scale = 0.2 }
+        }
+    }
+end

--- a/jokers/chan.lua
+++ b/jokers/chan.lua
@@ -57,3 +57,13 @@ SMODS.Joker {
         end
     end
 }
+
+if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
+    local jd_def = JokerDisplay.Definitions
+    jd_def["j_kcva_chan"] = {
+        text = {
+            { text = "+", colour = G.C.MULT },
+            { ref_table = "card.ability", ref_value = "mult", retrigger_type = "mult", colour = G.C.MULT }
+        }
+    }
+end

--- a/jokers/collapse.lua
+++ b/jokers/collapse.lua
@@ -46,7 +46,7 @@ SMODS.Joker {
             end
 
             for i, planet in ipairs(success_planets) do
-                -- need this bc OG doesn't accomodate for transforming planets
+                -- need this bc OG doesn't accommodate for transforming planets
                 planet.config.card = {}
                 G.E_MANAGER:add_event(Event({
                     func = function()
@@ -69,14 +69,14 @@ if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
     local jd_def = JokerDisplay.Definitions
     jd_def["j_kcva_collapse"] = {
         text = {
-            { text = "(", colour = G.C.GREEN, scale = 0.3 },
-            { ref_table = "card.joker_display_values", ref_value = "odds", colour = G.C.GREEN, scale = 0.3 },
-            { text = ")", colour = G.C.GREEN, scale = 0.3 },
+            { text = "(", colour = G.C.GREEN },
+            { ref_table = "card.joker_display_values", ref_value = "odds", colour = G.C.GREEN },
+            { text = ")", colour = G.C.GREEN },
         },
         reminder_text = {
-            { text = "(" },
-            { text = localize("b_stat_planets"), colour = G.C.SECONDARY_SET.Planet },
-            { text = ")" }
+            { text = "(", scale = 0.2 },
+            { text = localize("b_stat_planets"), colour = G.C.SECONDARY_SET.Planet, scale = 0.2 },
+            { text = ")", scale = 0.2 }
         },
         calc_function = function(card)
             card.joker_display_values.odds = localize { type = 'variable', key = "jdis_odds", vars = { (G.GAME and G.GAME.probabilities.normal or 1), 2 } }

--- a/jokers/collapse.lua
+++ b/jokers/collapse.lua
@@ -64,3 +64,22 @@ SMODS.Joker {
         end
     end
 }
+
+if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
+    local jd_def = JokerDisplay.Definitions
+    jd_def["j_kcva_collapse"] = {
+        text = {
+            { text = "(", colour = G.C.GREEN, scale = 0.3 },
+            { ref_table = "card.joker_display_values", ref_value = "odds", colour = G.C.GREEN, scale = 0.3 },
+            { text = ")", colour = G.C.GREEN, scale = 0.3 },
+        },
+        reminder_text = {
+            { text = "(" },
+            { text = localize("b_stat_planets"), colour = G.C.SECONDARY_SET.Planet },
+            { text = ")" }
+        },
+        calc_function = function(card)
+            card.joker_display_values.odds = localize { type = 'variable', key = "jdis_odds", vars = { (G.GAME and G.GAME.probabilities.normal or 1), 2 } }
+        end
+    }
+end

--- a/jokers/composition.lua
+++ b/jokers/composition.lua
@@ -113,3 +113,20 @@ SMODS.Joker {
         end
     end
 }
+
+if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
+    local jd_def = JokerDisplay.Definitions
+    jd_def["j_kcva_composition"] = {
+        text = {
+            { text = "+", colour = G.C.MULT },
+            { ref_table = "card.joker_display_values", ref_value = "mult", retrigger_type = "mult", colour = G.C.MULT },
+            { text = "+", colour = G.C.CHIPS },
+            { ref_table = "card.joker_display_values", ref_value = "chips", retrigger_type = "mult", colour = G.C.CHIPS }
+        },
+        calc_function = function(card)
+            local effect = kcv_composition_calc_effect(card, card.ability.extra.mult, card.ability.extra.chips)
+            card.joker_display_values.mult = effect.mult
+            card.joker_display_values.chips = effect.chips
+        end
+    }
+end

--- a/jokers/energy.lua
+++ b/jokers/energy.lua
@@ -62,3 +62,27 @@ SMODS.Joker {
         end
     end
 }
+
+if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
+    local jd_def = JokerDisplay.Definitions
+    jd_def["j_kcva_energy"] = {
+        text = {
+            { text = "+10", colour = G.C.MULT },
+            { text = " " .. localize("k_or") .. " " },
+            { text = "+100", colour = G.C.CHIPS },
+            { text = " " .. localize("k_or") .. " " },
+            {
+                border_nodes = {
+                    { text = "X2", scale = 0.3 }
+                }
+            },
+            { text = " " .. localize("k_or") .. " ", scale = 0.2 },
+            { text = "$5", colour = G.C.MONEY, scale = 0.2 }
+        },
+        reminder_text = {
+            { text = "(" },
+            { text = "Wild Cards", colour = G.C.IMPORTANT }, -- No localization for "Wild", "Cards", or "Wildcard(s)"
+            { text = ")" }
+        }
+    }
+end

--- a/jokers/energy.lua
+++ b/jokers/energy.lua
@@ -73,16 +73,17 @@ if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
             { text = " " .. localize("k_or") .. " " },
             {
                 border_nodes = {
-                    { text = "X2", scale = 0.3 }
+                    { text = "X2", scale = 0.25 }
                 }
             },
             { text = " " .. localize("k_or") .. " ", scale = 0.2 },
             { text = "$5", colour = G.C.MONEY, scale = 0.2 }
         },
         reminder_text = {
-            { text = "(" },
-            { text = "Wild Cards", colour = G.C.IMPORTANT }, -- No localization for "Wild", "Cards", or "Wildcard(s)"
-            { text = ")" }
+            { text = "(", scale = 0.2 },
+            { text = "Wild ", colour = G.C.IMPORTANT, scale = 0.2 }, -- No localization for "Wild"
+            { text = "Cards", colour = G.C.WHITE, scale = 0.2 },     -- No localization for "Cards"
+            { text = ")", scale = 0.2 }
         }
     }
 end

--- a/jokers/fortunecookie.lua
+++ b/jokers/fortunecookie.lua
@@ -77,3 +77,13 @@ SMODS.Joker {
         end
     end
 }
+
+if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
+    local jd_def = JokerDisplay.Definitions
+    jd_def["j_kcva_fortunecookie"] = {
+        text = {
+            { text = "+", colour = G.C.CHIPS },
+            { ref_table = "card.ability.extra", ref_value = "chips", retrigger_type = "mult", colour = G.C.CHIPS }
+        }
+    }
+end

--- a/jokers/guard.lua
+++ b/jokers/guard.lua
@@ -68,17 +68,19 @@ if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
     local jd_def = JokerDisplay.Definitions
     jd_def["j_kcva_guard"] = {
         text = {
-            { ref_table = "card.joker_display_values", ref_value = "active", colour = G.C.FILTER },
+            { ref_table = "card.joker_display_values", ref_value = "progress" },
         },
         reminder_text = {
-            { text = localize("King", "ranks") .. "s", colour = G.C.IMPORTANT },
-            { text = " " .. localize("k_or") .. " " },
-            { text = localize("Queen", "ranks") .. "s", colour = G.C.IMPORTANT }
+            { text = "(", scale = 0.2 },
+            { text = localize("King", "ranks") .. "s", colour = G.C.IMPORTANT, scale = 0.2 },
+            { text = " " .. localize("k_or") .. " ", scale = 0.2 },
+            { text = localize("Queen", "ranks") .. "s", colour = G.C.IMPORTANT, scale = 0.2 },
+            { text = ")", scale = 0.2 }
         },
         calc_function = function(card)
-            local sell_ready = card.ability.progress >= card.ability.required_progress
-            card.joker_display_values.active = sell_ready and localize("k_active_ex") or
-                (card.ability.progress .. "/" .. card.ability.required_progress)
+            local active = card.ability.progress >= card.ability.required_progress
+            local remaining = card.ability.required_progress - card.ability.progress
+            card.joker_display_values.progress = localize { type = 'variable', key = active and 'loyalty_active' or 'loyalty_inactive', vars = { remaining } }
         end
     }
 end

--- a/jokers/guard.lua
+++ b/jokers/guard.lua
@@ -63,3 +63,22 @@ SMODS.Joker {
         end
     end
 }
+
+if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
+    local jd_def = JokerDisplay.Definitions
+    jd_def["j_kcva_guard"] = {
+        text = {
+            { ref_table = "card.joker_display_values", ref_value = "active", colour = G.C.FILTER },
+        },
+        reminder_text = {
+            { text = localize("King", "ranks") .. "s", colour = G.C.IMPORTANT },
+            { text = " " .. localize("k_or") .. " " },
+            { text = localize("Queen", "ranks") .. "s", colour = G.C.IMPORTANT }
+        },
+        calc_function = function(card)
+            local sell_ready = card.ability.progress >= card.ability.required_progress
+            card.joker_display_values.active = sell_ready and localize("k_active_ex") or
+                (card.ability.progress .. "/" .. card.ability.required_progress)
+        end
+    }
+end

--- a/jokers/handy.lua
+++ b/jokers/handy.lua
@@ -56,3 +56,17 @@ SMODS.Joker {
         end
     end
 }
+
+if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
+    local jd_def = JokerDisplay.Definitions
+    jd_def["j_kcva_handy"] = {
+        text = {
+            {
+                border_nodes = {
+                    { text = "X" },
+                    { ref_table = "card.ability", ref_value = "x_mult", retrigger_type = "exp" }
+                }
+            }
+        }
+    }
+end

--- a/jokers/irish.lua
+++ b/jokers/irish.lua
@@ -29,7 +29,7 @@ SMODS.Joker {
     config = {},
     loc_txt = {
         name = "Luck of the Irish",
-        text = {"{C:attention}Lucky{} {C:clubs}Clubs{} are {C:green}4X{} more", "likely to succeed"}
+        text = { "{C:attention}Lucky{} {C:clubs}Clubs{} are {X:green,C:white} 4X {} more", "likely to successfully trigger" }
     },
     loc_vars = function(self, info_queue, card)
         return {

--- a/jokers/irish.lua
+++ b/jokers/irish.lua
@@ -39,3 +39,19 @@ SMODS.Joker {
     calculate = function(self, card, context)
     end
 }
+
+if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
+    local jd_def = JokerDisplay.Definitions
+    jd_def["j_kcva_irish"] = {
+        text = {
+            {
+                border_nodes = {
+                    { text = "4X" }
+                },
+                border_colour = G.C.CHANCE
+            },
+            { text = " Lucky ", colour = G.C.IMPORTANT }, -- No localization for "Lucky"
+            { text = localize("Clubs", "suits_plural"), colour = lighten(G.C.SUITS["Clubs"], 0.35) }
+        }
+    }
+end

--- a/jokers/irish.lua
+++ b/jokers/irish.lua
@@ -44,14 +44,14 @@ if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
     local jd_def = JokerDisplay.Definitions
     jd_def["j_kcva_irish"] = {
         text = {
+            { text = "Lucky ", colour = G.C.IMPORTANT }, -- No localization for "Lucky"
+            { text = localize("Clubs", "suits_plural").." ", colour = G.C.SUITS.Clubs },
             {
                 border_nodes = {
                     { text = "4X" }
                 },
                 border_colour = G.C.CHANCE
-            },
-            { text = " Lucky ", colour = G.C.IMPORTANT }, -- No localization for "Lucky"
-            { text = localize("Clubs", "suits_plural"), colour = lighten(G.C.SUITS["Clubs"], 0.35) }
+            }
         }
     }
 end

--- a/jokers/powergrid.lua
+++ b/jokers/powergrid.lua
@@ -43,3 +43,31 @@ SMODS.Joker {
         end
     end
 }
+
+if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
+    local jd_def = JokerDisplay.Definitions
+    jd_def["j_kcva_powergrid"] = {
+        --[[
+            This PR includes tooltips for all Jokers except for Power Grid. I don't understand what that Joker does...
+
+            I assume it should be starting at "x1.0" and gaining "x0.2" for every playing card scored with +Mult, then resetting on round end.
+            Testing in game, however, I can't get it to increase (or decrease) from "x1.2"... It even starts the round at "x1.2"!
+            And even while claiming "x1.2", it doesn't seem to ever actually apply that "x0.2" mult anywhere. Played hands just skip this Joker.
+            I've tried +Mult, xMult, Holographic, Polychrome, Lucky, and Red Seal. Nothing changes. The code looks fine, so I don't understand.
+
+            Testing was done with:
+                - Balatro 1.0.1g
+                - Lovely 0.5.0-beta7
+                - Steammodded 1.0.0-1006a
+                - "_RELEASE_MODE = false"
+
+            I wasn't even including JokerDisplay compat in testing, just this mod and the Joker's core functionality.
+
+            *shrugs* I'm leaving it with no display for now. I don't want to add something that I cannot test for.
+            I assume just a simple "x_mult" border_node is all that is needed. (Can be copied directly from Handy.)
+            Please discuss within this PR (or Discord) and I will update it, or you may merge this and do so yourself.
+
+            ~Toranaado (@TehSeph)
+        ]] --
+    }
+end

--- a/jokers/powergrid.lua
+++ b/jokers/powergrid.lua
@@ -47,27 +47,18 @@ SMODS.Joker {
 if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
     local jd_def = JokerDisplay.Definitions
     jd_def["j_kcva_powergrid"] = {
-        --[[
-            This PR includes tooltips for all Jokers except for Power Grid. I don't understand what that Joker does...
-
-            I assume it should be starting at "x1.0" and gaining "x0.2" for every playing card scored with +Mult, then resetting on round end.
-            Testing in game, however, I can't get it to increase (or decrease) from "x1.2"... It even starts the round at "x1.2"!
-            And even while claiming "x1.2", it doesn't seem to ever actually apply that "x0.2" mult anywhere. Played hands just skip this Joker.
-            I've tried +Mult, xMult, Holographic, Polychrome, Lucky, and Red Seal. Nothing changes. The code looks fine, so I don't understand.
-
-            Testing was done with:
-                - Balatro 1.0.1g
-                - Lovely 0.5.0-beta7
-                - Steammodded 1.0.0-1006a
-                - "_RELEASE_MODE = false"
-
-            I wasn't even including JokerDisplay compat in testing, just this mod and the Joker's core functionality.
-
-            *shrugs* I'm leaving it with no display for now. I don't want to add something that I cannot test for.
-            I assume just a simple "x_mult" border_node is all that is needed. (Can be copied directly from Handy.)
-            Please discuss within this PR (or Discord) and I will update it, or you may merge this and do so yourself.
-
-            ~Toranaado (@TehSeph)
-        ]] --
+        text = {
+            { text = "Next " },
+            { text = "Mult ", colour = G.C.IMPORTANT }, -- No localization for "Mult"
+            { text = "Card " },                         -- No localization for "Cards"
+            {
+                border_nodes = {
+                    { ref_table = "card.joker_display_values", ref_value = "next_xmult", retrigger_type = "exp" }
+                }
+            }
+        },
+        calc_function = function(card)
+            card.joker_display_values.next_xmult = "X"..(1 + card.ability.extra + ((G.GAME.current_round.kcv_mults_scored or 0) * card.ability.extra))
+        end
     }
 end

--- a/jokers/powergrid.lua
+++ b/jokers/powergrid.lua
@@ -15,7 +15,8 @@ SMODS.Joker {
     blueprint_compat = true,
     -- enhancement_gate = 'm_mult',
     config = {
-        extra = 0.2
+        extra = 0.2,
+        jd_xmult = 1
     },
     loc_txt = {
         name = "Power Grid",
@@ -48,17 +49,26 @@ if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
     local jd_def = JokerDisplay.Definitions
     jd_def["j_kcva_powergrid"] = {
         text = {
-            { text = "Next " },
-            { text = "Mult ", colour = G.C.IMPORTANT }, -- No localization for "Mult"
-            { text = "Card " },                         -- No localization for "Cards"
             {
                 border_nodes = {
-                    { ref_table = "card.joker_display_values", ref_value = "next_xmult", retrigger_type = "exp" }
+                    { text = "X" },
+                    { ref_table = "card.ability", ref_value = "jd_xmult", retrigger_type = "exp" }
                 }
             }
         },
         calc_function = function(card)
-            card.joker_display_values.next_xmult = "X"..(1 + card.ability.extra + ((G.GAME.current_round.kcv_mults_scored or 0) * card.ability.extra))
+            local total = 1
+            local mod = 1 + ((G.GAME.current_round.kcv_mults_scored or 0) * card.ability.extra)
+            local text, poker_hands, scoring_hand = JokerDisplay.evaluate_hand()
+            for _, scoring_card in pairs(scoring_hand) do
+                if scoring_card.ability.name == 'Mult' and not scoring_card.debuff then
+                    mod = mod + card.ability.extra
+                    total = total * mod
+                end
+            end
+            if not next(G.play.cards) then
+                card.ability.jd_xmult = total
+            end
         end
     }
 end

--- a/jokers/redenvelope.lua
+++ b/jokers/redenvelope.lua
@@ -39,11 +39,11 @@ if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
             { ref_table = "card.joker_display_values", ref_value = "bonus", retrigger_type = "mult", colour = G.C.MONEY }
         },
         reminder_text = {
-            { text = "(" },
-            { text = localize("k_common"), colour = G.C.BLUE },
-            { text = " " },
-            { text = localize("b_jokers"), colour = G.C.JOKER_GREY },
-            { text = ")" }
+            { text = "(", scale = 0.2 },
+            { text = localize("k_common"), colour = G.C.BLUE, scale = 0.2 },
+            { text = " ", scale = 0.2 },
+            { text = localize("b_jokers"), colour = G.C.JOKER_GREY, scale = 0.2 },
+            { text = ")", scale = 0.2 }
         },
         calc_function = function(card)
             card.joker_display_values.bonus = 8 * kcv_common_joker_count()

--- a/jokers/redenvelope.lua
+++ b/jokers/redenvelope.lua
@@ -30,3 +30,23 @@ SMODS.Joker {
         end
     end
 }
+
+if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
+    local jd_def = JokerDisplay.Definitions
+    jd_def["j_kcva_redenvelope"] = {
+        text = {
+            { text = "+$", colour = G.C.MONEY },
+            { ref_table = "card.joker_display_values", ref_value = "bonus", retrigger_type = "mult", colour = G.C.MONEY }
+        },
+        reminder_text = {
+            { text = "(" },
+            { text = localize("k_common"), colour = G.C.BLUE },
+            { text = " " },
+            { text = localize("b_jokers"), colour = G.C.JOKER_GREY },
+            { text = ")" }
+        },
+        calc_function = function(card)
+            card.joker_display_values.bonus = 8 * kcv_common_joker_count()
+        end
+    }
+end

--- a/jokers/robo.lua
+++ b/jokers/robo.lua
@@ -62,3 +62,13 @@ SMODS.Joker {
         end
     end
 }
+
+if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
+    local jd_def = JokerDisplay.Definitions
+    jd_def["j_kcva_robo"] = {
+        text = {
+            { text = "+", colour = G.C.CHIPS },
+            { ref_table = "card.ability", ref_value = "chips", retrigger_type = "mult", colour = G.C.CHIPS }
+        }
+    }
+end

--- a/jokers/squid.lua
+++ b/jokers/squid.lua
@@ -67,7 +67,7 @@ if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
         text = {
             { text = "+", colour = G.C.FILTER },
             { ref_table = "card.ability", ref_value = "h_size", colour = G.C.FILTER },
-            { text = " Hand Size", colour = G.C.FILTER }
+            { text = " Hand Size", colour = G.C.FILTER } -- No localization for "Hand Size"
         }
     }
 end

--- a/jokers/squid.lua
+++ b/jokers/squid.lua
@@ -60,3 +60,14 @@ SMODS.Joker {
         end
     end
 }
+
+if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
+    local jd_def = JokerDisplay.Definitions
+    jd_def["j_kcva_squid"] = {
+        text = {
+            { text = "+", colour = G.C.FILTER },
+            { ref_table = "card.ability", ref_value = "h_size", colour = G.C.FILTER },
+            { text = " Hand Size", colour = G.C.FILTER }
+        }
+    }
+end

--- a/jokers/swiss.lua
+++ b/jokers/swiss.lua
@@ -58,3 +58,13 @@ SMODS.Joker {
         end
     end
 }
+
+if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
+    local jd_def = JokerDisplay.Definitions
+    jd_def["j_kcva_swiss"] = {
+        text = {
+            { text = "+", colour = G.C.MULT },
+            { ref_table = "card.ability", ref_value = "mult", retrigger_type = "mult", colour = G.C.MULT }
+        }
+    }
+end

--- a/jokers/tenpin.lua
+++ b/jokers/tenpin.lua
@@ -81,11 +81,15 @@ if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
         },
         extra = {
             {
-                { text = "(" },
-                { ref_table = "card.ability", ref_value = "hands_remaining" },
-                { text = localize("k_hud_hands") .. " " .. localize("b_remaining") },
-                { text = ")" }
+                { text = "(", scale = 0.2 },
+                { ref_table = "card.joker_display_values", ref_value = "remaining", scale = 0.2 }, -- bugfix, see below
+                { text = localize("k_hud_hands") .. " " .. localize("b_remaining"), scale = 0.2 },
+                { text = ")", scale = 0.2 }
             }
-        }
+        },
+        -- This is required because of a bug in the code above allowing "card.ability.hands_remaining" to go negative
+        calc_function = function(card)
+            card.joker_display_values.remaining = (card.ability.hands_remaining > 0) and card.ability.hands_remaining or 0
+        end
     }
 end

--- a/jokers/tenpin.lua
+++ b/jokers/tenpin.lua
@@ -67,3 +67,25 @@ SMODS.Joker {
         end
     end
 }
+
+if SMODS.Mods['JokerDisplay'] and _G['JokerDisplay'] then
+    local jd_def = JokerDisplay.Definitions
+    jd_def["j_kcva_tenpin"] = {
+        text = {
+            {
+                border_nodes = {
+                    { text = "X" },
+                    { ref_table = "card.ability", ref_value = "x_mult", retrigger_type = "exp" }
+                }
+            }
+        },
+        extra = {
+            {
+                { text = "(" },
+                { ref_table = "card.ability", ref_value = "hands_remaining" },
+                { text = localize("k_hud_hands") .. " " .. localize("b_remaining") },
+                { text = ")" }
+            }
+        }
+    }
+end

--- a/site/addjokers.js
+++ b/site/addjokers.js
@@ -93,7 +93,7 @@ let jokers = [
 	},
 	{
 		name: 'Luck of the Irish',
-		text: ['Lucky Clubs are 4X more likely to succeed'],
+		text: ['Lucky Clubs are 4X more likely to successfully trigger'],
 		image_url: 'assets/originals/irish.png',
 		rarity: 'Rare',
 	},


### PR DESCRIPTION
This PR includes https://github.com/nh6574/JokerDisplay tooltips for all KCVanilla Jokers ~~except for `Power Grid`.~~

~~I don't understand what `Power Grid` does... I assume it should be starting at `x1.0` and gaining `x0.2` for every playing card scored with +Mult, then resetting on round end. Testing in game, however, I can't get it to increase (or decrease) from `x1.2`... It even starts the round at `x1.2`! And while claiming `x1.2`, it doesn't seem to ever actually apply that `x0.2` mult anywhere. Played hands just skip over this Joker. I've tried `+Mult`, `xMult`, `Holographic`, `Polychrome`, `Lucky`, and `Red Seal`. Nothing changes. Your code looks fine, so I don't understand.~~

Testing was done with:
- Balatro 1.0.1g
- Lovely 0.5.0-beta7
- Steammodded 1.0.0-1006a
- "_RELEASE_MODE = false"

~~I wasn't even including `JokerDisplay` compat in testing, just this mod and the Joker's core functionality.~~

~~\*shrugs\* I'm leaving it with no display for now. I don't want to add something that I cannot test for.~~
~~I assume just a simple `x_mult` border_node is all that is needed. (Can be copied directly from Handy.)~~
~~Please discuss within this PR (or Discord) and I will update it, or you may merge this and do so yourself.~~

Also included is a change to the description of `Luck of the Irish` as a separate commit [`f2fe505`](https://github.com/kcgidw/kcvanilla/pull/1/commits/f2fe50520412adbe6568b2e7fdbc94dfe0d7848d) to be cherrypicked if undesired. This change puts the description in parity with the visuals of the new tooltip and improves its readability IMO

![New Description](https://i.imgur.com/VGLRJCd.png) ![New Tooltip](https://i.imgur.com/1LgQkau.png)