### PR TITLE
Add extra info to tooltips

### DIFF
--- a/jokers/collapse.lua
+++ b/jokers/collapse.lua
@@ -20,6 +20,7 @@ SMODS.Joker {
                 'to transform into a {C:spectral}Black Hole{}'}
     },
     loc_vars = function(self, info_queue, card)
+        info_queue[#info_queue + 1] = G.P_CENTERS.c_black_hole
         return {
             vars = {'' .. (G.GAME and G.GAME.probabilities.normal or 1)}
         }

--- a/jokers/energy.lua
+++ b/jokers/energy.lua
@@ -28,6 +28,7 @@ SMODS.Joker {
                 '{C:mult}+#1#{} Mult, {C:chips}+#2#{} Chips, {X:mult,C:white} X#3# {} Mult, {C:money}$#4#{}'}
     },
     loc_vars = function(self, info_queue, card)
+        info_queue[#info_queue + 1] = G.P_CENTERS.m_wild
         return {
             vars = {card.ability.kcv.mult, card.ability.kcv.chips, card.ability.kcv.Xmult, card.ability.kcv.money}
         }

--- a/jokers/guard.lua
+++ b/jokers/guard.lua
@@ -23,6 +23,7 @@ SMODS.Joker {
                 "random Joker {C:dark_edition}Negative{}", "{C:inactive}(Progress: #1#/#2#){}"}
     },
     loc_vars = function(self, info_queue, card)
+        info_queue[#info_queue + 1] = G.P_CENTERS.e_negative
         return {
             vars = {card.ability.progress, card.ability.required_progress}
         }

--- a/jokers/irish.lua
+++ b/jokers/irish.lua
@@ -25,7 +25,7 @@ SMODS.Joker {
     eternal_compat = true,
     perishable_compat = true,
     blueprint_compat = false,
-    enhancement_gate = 'm_lucky',
+    -- enhancement_gate = 'm_lucky',
     config = {},
     loc_txt = {
         name = "Luck of the Irish",

--- a/jokers/irish.lua
+++ b/jokers/irish.lua
@@ -25,13 +25,14 @@ SMODS.Joker {
     eternal_compat = true,
     perishable_compat = true,
     blueprint_compat = false,
-    -- enhancement_gate = 'm_lucky',
+    enhancement_gate = 'm_lucky',
     config = {},
     loc_txt = {
         name = "Luck of the Irish",
         text = {"{C:attention}Lucky{} {C:clubs}Clubs{} are {C:green}4X{} more", "likely to succeed"}
     },
     loc_vars = function(self, info_queue, card)
+        info_queue[#info_queue + 1] = G.P_CENTERS.m_lucky
         return {
             vars = {}
         }

--- a/jokers/powergrid.lua
+++ b/jokers/powergrid.lua
@@ -13,7 +13,7 @@ SMODS.Joker {
     eternal_compat = true,
     perishable_compat = true,
     blueprint_compat = true,
-    -- enhancement_gate = 'm_mult',
+    enhancement_gate = 'm_mult',
     config = {
         extra = 0.2
     },
@@ -24,6 +24,7 @@ SMODS.Joker {
                 "{C:inactive}(Next: {X:mult,C:white} X#2# {C:inactive} Mult)"}
     },
     loc_vars = function(self, info_queue, card)
+        info_queue[#info_queue + 1] = G.P_CENTERS.m_mult
         local xmult = 1 + card.ability.extra + ((G.GAME.current_round.kcv_mults_scored or 0) * card.ability.extra)
         return {
             vars = {card.ability.extra, xmult}


### PR DESCRIPTION
To match how vanilla cards like Lucky Cat do it, I made the following jokers display extra tooltips:

* Cosmic Collapse (black hole)
* Joker Energy (wild card)
* Royal Guard (negative)
* Luck of the Irish (lucky card)
* Power Grid (mult card)

I also uncommented the enhancement gate for luck and power grid cause that's how I wanna play with them but not sure if the commenting was intended (I'm guessing not cause it was uncommented on joker energy).