### PR TITLE
Add Brazilian Portuguese localization (and default en-us loc)

### DIFF
--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1,0 +1,133 @@
+return {
+	descriptions = {
+		Joker = {
+			j_kcvanilla_5day = {
+				name = "Five-Day Forecast",
+				text = {
+					"If played hand contains a {C:attention}Straight{},",
+					"increase played cards' ranks by {C:attention}1{}",
+					"{C:inactive}(Excludes {C:attention}Aces{C:inactive})",
+				}
+			  },
+			j_kcvanilla_chan = {
+				name = "Joker-chan",
+				text = {
+					"At end of round, gains {C:mult}+#1#{} Mult", 
+					"for each {C:blue}Common{} Joker",
+					"{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult){}",
+				}
+			},
+			j_kcvanilla_collapse = {
+				name = "Cosmic Collapse",
+				text = {
+					'At end of round, held {C:planet}Planet{}', 
+					'cards each have {C:green}#1# in 2{} chance',
+					'to transform into a {C:spectral}Black Hole{}',
+				}
+			},
+			j_kcvanilla_composition = {
+				name = "Composition",
+				text = {
+					"{C:mult}+#1#{} Mult for each Joker to the left,", 
+					"{C:chips}+#2#{} Chips for each Joker to the right",
+					"{C:inactive}(Currently {C:mult}+#3#{C:inactive} Mult and {C:chips}+#4#{C:inactive} Chips){}"
+				}
+			},
+			j_kcvanilla_energy = {
+				name = "Joker Energy",
+				text = {
+					'Played {C:attention}Wild{} cards give one', 
+					'of the following when scored:',
+					'{C:mult}+#1#{} Mult, {C:chips}+#2#{} Chips, {X:mult,C:white} X#3# {} Mult, {C:money}$#4#{}'
+				}
+			},
+			j_kcvanilla_fortunecookie = {
+				name = "Fortune Cookie",
+				text = {
+					"{C:chips}+#1#{} Chips,", 
+					"{C:chips}-#2#{} Chips when", 
+					"{C:tarot}Tarot{} card is used"
+				}
+			},
+			j_kcvanilla_guard = {
+				name = "Royal Guard",
+				text = {
+					"After {C:attention}#2#{} {C:attention}Kings{} or {C:attention}Queens{}", 
+					"score, sell this to make a",
+					"random Joker {C:dark_edition}Negative{}",
+					"{C:inactive}(Progress: #1#/#2#){}"
+				}
+			},
+			j_kcvanilla_handy = {
+				name = "Handy Joker",
+				text = {
+					'If first discard of round', 
+					'is a single enhanced card,',
+					'gain {X:mult,C:white} X1 {} Mult, resets when', 
+					'Boss Blind is defeated',
+					'{C:inactive}(Currently {X:mult,C:white} X#1# {C:inactive} Mult)'
+				}
+			},
+			j_kcvanilla_irish = {
+				name = "Luck of the Irish",
+				text = {
+					"{C:attention}Lucky{} {C:clubs}Clubs{} are {C:green}4X{} more", 
+					"likely to succeed"
+				}
+			},
+			j_kcvanilla_powergrid = {
+				name = "Power Grid",
+				text = {
+					'Scored {C:attention}Mult{} cards give {X:mult,C:white} X#1# {} Mult',
+					'for each {C:attention}Mult{} card scored this round',
+					"{C:inactive}(Next: {X:mult,C:white} X#2# {C:inactive} Mult)"
+				}
+			},
+			j_kcvanilla_redenvelope = {
+				name = "Red Envelope",
+				text = {
+					'When Boss Blind is defeated,',
+					'earn {C:money}$8{} for each {C:blue}Common{} Joker',
+					'{C:inactive}(Currently {C:money}$#1#{C:inactive})'
+				}
+			},
+			j_kcvanilla_robo = {
+				name = "Jimbot",
+				text = {
+					"Gains the {C:chips}Chip{} value of the first", 
+					"scored card ranked {C:attention}2-10{} each round",
+					"{C:inactive}(Currently {C:chips}+#1#{C:inactive} Chips)"
+				}
+			},
+			j_kcvanilla_squid = {
+				name = "Squid",
+				text = {
+					"{C:attention}+#1#{} hand size on final", 
+					"2 hands of round", "{C:inactive}#2#"
+				}
+			},
+			j_kcvanilla_swiss = {
+				name = "Swiss Joker",
+				text = {
+					'{C:mult}+#1#{} Mult for each', 
+					'card played in previous hand', 
+					'that did not score',
+					'{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult)'
+				}
+			},
+			j_kcvanilla_tenpin = {
+				name = "Ten-Pin",
+				text = {
+					'If played hand contains a scoring {C:attention}10{},', 
+					'{X:mult,C:white} X2 {} Mult for next 2 hands',
+					'{C:inactive}#1#{}'
+				}
+			},
+		},
+	},
+	misc = {
+		dictionary = {},
+		v_dictionary = {}
+	}
+}
+

--- a/localization/pt_BR.lua
+++ b/localization/pt_BR.lua
@@ -1,0 +1,138 @@
+return {
+	descriptions = {
+		Joker = {
+			j_kcvanilla_5day = {
+				name = "Previsão de Cinco Dias",
+				text = {
+					"Se a mão jogada contém uma",
+					"{C:attention}Sequência{}, aumenta a classe",
+					"das cartas jogadas em {C:attention}1{}",
+					"{C:inactive}(Exceto {C:attention}Ázes{C:inactive})"
+				}
+			},
+			j_kcvanilla_chan = {
+				name = "Curinga-chan",
+				text = {
+					"No fim da rodada, ganha {C:mult}+#1#{} Multi", 
+					"por cada Curinga {C:blue}Comum{}",
+					"{C:inactive}(No momento, {C:mult}+#2#{C:inactive} Multi){}"
+				}
+			},
+			j_kcvanilla_collapse = {
+				name = "Colapso Cósmico",
+				text = {
+					'No fim da rodada, cartas de {C:planet}Planeta{}', 
+					'contidas na mão têm {C:green}#1# em 2{} chances',
+					'de tornarem-se um {C:spectral}Buraco Negro{}'
+				}
+			},
+			j_kcvanilla_composition = {
+				name = "Composição",
+				text = {
+					"{C:mult}+#1#{} Multi por cada Curinga à esquerda,", 
+					"{C:chips}+#2#{} Fichas por cada Curinga à direita",
+					"{C:inactive}(No momento, {C:mult}+#3#{C:inactive} Multi e {C:chips}+#4#{C:inactive} Fichas){}"
+				}
+			},
+			j_kcvanilla_energy = {
+				name = "Joker Energy",
+				text = {
+					'Cartas {C:attention}Naipe Curinga{} dão um dos', 
+					'seguintes bônus quando pontuadas:',
+					'{C:mult}+#1#{} Multi, {C:chips}+#2#{} Fichas, {X:mult,C:white} X#3# {} Multi ou {C:money}$#4#{}'
+				}
+			},
+			j_kcvanilla_fortunecookie = {
+				name = "Biscoito da Sorte",
+				text = {
+					"{C:chips}+#1#{} Fichas,", 
+					"{C:chips}-#2#{} Fichas quando uma", 
+					"carta de {C:tarot}Tarô{} é usada"
+				}
+			},
+			j_kcvanilla_guard = {
+				name = "Guarda Real",
+				text = {
+					"Após {C:attention}#2#{} {C:attention}Reis{} ou {C:attention}Rainhas{}", 
+					"pontuarem, venda este Curinga para",
+					"criar um Curinga {C:dark_edition}Negativo{} aleatório",
+					"{C:inactive}(Progresso: #1#/#2#){}"
+				}
+			},
+			j_kcvanilla_handy = {
+				name = "Mãozinha Curinga",
+				text = {
+					'Se o primeiro descarte da rodada', 
+					'for uma única carta {C:attention}Aprimorada{},',
+					'ganha {X:mult,C:white}X1{} Multi, reseta quando', 
+					'o Blind de Chefe é derrotado',
+					'{C:inactive}(No momento, {X:mult,C:white} X#1# {C:inactive} Multi)'
+				}
+			},
+			j_kcvanilla_irish = {
+				name = "Sorte de Irlandês",
+				text = {
+					"{C:attention}Cartas de Sorte{} de {C:clubs}Paus{}",
+					"têm {C:green}4X{} mais chances", 
+					"de darem seus bônus"
+				}
+			},
+			j_kcvanilla_powergrid = {
+				name = "Rede Elétrica",
+				text = {
+					'{C:attention}Cartas Multi{} pontuadas dão ',
+					'{X:mult,C:white}X#1#{} Multi por cada {C:attention}Carta Multi{}',
+					'pontuada nesta rodada',
+					"{C:inactive}(Próxima: {X:mult,C:white} X#2# {C:inactive} Multi)"
+				}
+			},
+			j_kcvanilla_redenvelope = {
+				name = "Envelope Vermelho",
+				text = {
+					'Quando Blind de Chefe é derrotado,',
+					'ganhe {C:money}$8{} por cada Curinga {C:blue}Comum{}',
+					'{C:inactive}(No momento, {C:money}$#1#{C:inactive})'
+				}
+			},
+			j_kcvanilla_robo = {
+				name = "Jimbot",
+				text = {
+					"Ganha o valor de {C:chips}Fichas{} da", 
+					"primeira carta pontuada de,",
+					"classe {C:attention}2-10{} cada rodada",
+					"{C:inactive}(No momento, {C:chips}+#1#{C:inactive} Fichas)"
+				}
+			},
+			j_kcvanilla_squid = {
+				name = "Lula",
+				text = {
+					"{C:attention}+#1#{} tamanho de mão nas", 
+					"2 últimas mãos da rodada", 
+					"{C:inactive}#2#"
+				}
+			},
+			j_kcvanilla_swiss = {
+				name = "Curinga Suíço",
+				text = {
+					'{C:mult}+#1#{} Multi por cada carta', 
+					'jogada na mão anterior', 
+					'e não foi pontuada',
+					'{C:inactive}(No momento, {C:mult}+#2#{C:inactive} Multi)'
+				}
+			},
+			j_kcvanilla_tenpin = {
+				name = "Dez Pinos",
+				text = {
+					'Se a mão jogada contém',
+					'um {C:attention}10{} pontuado, {X:mult,C:white} X2 {} Multi', 
+					'pelas próximas 2 mãos',
+					'{C:inactive}#1#{}'
+				}
+			}
+		}
+	},
+	misc = {
+		dictionary = {},
+		v_dictionary = {}
+	}
+}


### PR DESCRIPTION
Hello there!

I'm on a quest to translate all my favorite mods to Brazilian Portuguese. For this mod, there wasn't a localization folder, so I created one and put the pt_BR.lua loc file there. I figured I'd also put an en-us.lua file there with the english locs, in case you want to move the joker loc_text there (I wasn't sure if you'd want that, so I didn't mess with the joker .luas themselves)

For this reason I made two different commits: one with the pt-br localization and another with the en-us one, so you can choose whether or not to adopt each one