### PR TITLE
Mark fortune cookie as food for other mods

### DIFF
--- a/jokers/fortunecookie.lua
+++ b/jokers/fortunecookie.lua
@@ -12,6 +12,7 @@ SMODS.Joker {
     eternal_compat = false,
     perishable_compat = true,
     blueprint_compat = true,
+    pools = { Food = true },
     config = {
         extra = {
             chips = 150,


### PR DESCRIPTION
This marks it as a Food Joker for at least Paperback and Cryptid.

While Swiss Joker and Joker Energy are technically food themed they don't vibe like food jokers to me so haven't marked them.